### PR TITLE
fix: resolve BLE fallback crash on macOS (Future attached to different loop)

### DIFF
--- a/tests/test_bleak_socket.py
+++ b/tests/test_bleak_socket.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
+from unittest.mock import patch
 
 from timiniprint.transport.bluetooth.adapters.bleak_adapter import _BleakSocket
 from timiniprint.protocol.family import ProtocolFamily
@@ -186,6 +187,14 @@ class BleakSocketTests(unittest.TestCase):
         s = _BleakSocket(device_cache={"AA:BB:CC:DD:EE:FF": cached})
         target = asyncio.run(s._resolve_client_target("aa:bb:cc:dd:ee:ff"))
         self.assertIs(target, cached)
+
+    def test_resolve_client_target_bypasses_cache_for_uuid_addresses(self) -> None:
+        cached = object()
+        address = "2123321321-2CE0-8122-7AC5-29988EF86A08"
+        s = _BleakSocket(device_cache={address.upper(): cached})
+        with patch("timiniprint.transport.bluetooth.adapters.bleak_adapter.IS_MACOS", True):
+            target = asyncio.run(s._resolve_client_target(address.lower()))
+        self.assertEqual(target, address.lower())
 
     def test_close_cleanup_disconnect(self) -> None:
         s = _BleakSocket()

--- a/timiniprint/transport/bluetooth/adapters/bleak_adapter.py
+++ b/timiniprint/transport/bluetooth/adapters/bleak_adapter.py
@@ -146,9 +146,10 @@ class _BleakSocket:
 
     async def _resolve_client_target(self, address: str) -> Any:
         """Return the address or discovered device object passed to BleakClient."""
-        # On macOS, BLE addresses are UUIDs — pass them directly to avoid using
-        # a cached BleakDevice object that may be bound to a closed event loop.
-        if len(address) == 36 and address.count("-") == 4:
+        # On macOS, reuse of a cached BLEDevice from a previous scan loop can
+        # fail with "Future attached to a different loop". Pass the CoreBluetooth
+        # address string directly instead.
+        if IS_MACOS:
             return address
         cached = self._device_cache.get(address.upper())
         if cached is not None:

--- a/timiniprint/transport/bluetooth/adapters/bleak_adapter.py
+++ b/timiniprint/transport/bluetooth/adapters/bleak_adapter.py
@@ -146,11 +146,13 @@ class _BleakSocket:
 
     async def _resolve_client_target(self, address: str) -> Any:
         """Return the address or discovered device object passed to BleakClient."""
+        # On macOS, BLE addresses are UUIDs — pass them directly to avoid using
+        # a cached BleakDevice object that may be bound to a closed event loop.
+        if len(address) == 36 and address.count("-") == 4:
+            return address
         cached = self._device_cache.get(address.upper())
         if cached is not None:
             return cached
-        if len(address) == 36 and address.count("-") == 4:
-            return address
 
         try:
             from bleak import BleakScanner


### PR DESCRIPTION
Hi, 
I tried to run latest standalone on my macOS arm64, but encountered the following error:

```
❯ ./TiMini-Print-Command-Line-macOS-arm64 --text "Hello from CLI"
2026-04-10 16:30:30.101 TiMini-Print-Command-Line-macOS-arm64[34385:3557125] -[IOBluetoothDeviceInquiry initWithDelegate:] -  0x0
Warning: Classic Bluetooth connection failed, retrying over BLE (device: X6h-0000).
Error: Bluetooth connection failed (classic error: Bluetooth connection failed (channels tried: [1], last error: Failed to open RFCOMM channel 1 (status: -536870212)); ble fallback error: Bluetooth connection failed (channels tried: [1], last error: Failed to connect to BLE device 2123321321-2CE0-8122-7AC5-29988EF86A08: Task <Task pending name='Task-4' coro=<_BleakSocket._connect_async() running at timiniprint/transport/bluetooth/adapters/bleak_adapter.py:115> cb=[_run_until_complete_cb() at asyncio/base_events.py:181]> got Future <Future pending> attached to a different loop))
2026-04-10 16:30:41.964 TiMini-Print-Command-Line-macOS-arm64[34385:3557125] -[IOBluetoothDeviceInquiry dealloc] -  0x0
```

I ran claude who was able to find a simple fix. Please find the detail below. 
Thanks for this and hope that helps !
Paul

---

## Summary

- On macOS, BLE device addresses are CoreBluetooth UUIDs (e.g. `367993BA-2CE0-8122-7AC5-29988EF86A08`)
- `scan_blocking()` caches `BleakDevice` objects bound to a temporary event loop, then closes that loop
- When the Classic → BLE fallback runs, `_resolve_client_target` returns the stale cached object instead of the UUID string, causing bleak to fail with `"Future attached to a different loop"`

**Root cause** — in `_resolve_client_target`, the cache was consulted before the UUID format check:

```python
# Before (buggy)
cached = self._device_cache.get(address.upper())
if cached is not None:
    return cached  # returns object bound to a closed event loop
if len(address) == 36 and address.count("-") == 4:
    return address
```

**Fix** — move the UUID check first so macOS connections always use the address string directly:

```python
# After
if len(address) == 36 and address.count("-") == 4:
    return address  # macOS UUID: bypass the cache entirely
cached = self._device_cache.get(address.upper())
if cached is not None:
    return cached
```

This has no impact on Linux/Windows where addresses are MAC addresses and the cache remains useful.

## Reproduction

```
./TiMini-Print-Command-Line-macOS-arm64 --text "Hello"
# → Warning: Classic Bluetooth connection failed, retrying over BLE
# → Error: ... got Future <Future pending> attached to a different loop
```

## Test plan

- [ ] BLE fallback connects successfully on macOS after Classic fails
- [ ] Direct BLE connection still works on macOS
- [ ] Linux/Windows behavior unchanged (MAC address format does not match UUID check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)