### PR TITLE
Fix linux-att adapter wiring + V5X pagination & tolerant ACK waits

### DIFF
--- a/tests/test_bleak_transport_session.py
+++ b/tests/test_bleak_transport_session.py
@@ -1337,14 +1337,21 @@ class BleakTransportSessionTests(unittest.TestCase):
 
         data = V5X_GET_SERIAL_PACKET + (b"\xAA\x55" * 8) + V5X_FINALIZE_PACKET
 
+        # Command-ACK waits are advisory on V5X. When the printer does not
+        # reply within the timeout (e.g. paginated multi-segment jobs where
+        # the next-segment 0xA7 reply is preemptively consumed by a
+        # between-segments idle re-identification, or firmwares that
+        # simply do not reply per-command), the runtime logs and continues
+        # rather than aborting the send. The legacy behaviour raised
+        # TimeoutError; the new behaviour completes the send and still
+        # clears the per-job handshake state.
         async def run() -> None:
-            with self.assertRaises(TimeoutError):
-                await session.send(
-                    client,
-                    data,
-                    mtu_size=180,
-                    timeout=0.01,
-                )
+            await session.send(
+                client,
+                data,
+                mtu_size=180,
+                timeout=0.01,
+            )
 
         asyncio.run(run())
 

--- a/tests/test_bluetooth_adapter_fallback.py
+++ b/tests/test_bluetooth_adapter_fallback.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import threading
 import unittest
+from unittest import mock
 
 from tests.helpers import build_capture_reporter
 from timiniprint.transport.bluetooth.adapters.adapter_fallback import _FallbackAdapter, _FallbackSocket
@@ -159,6 +161,31 @@ class BluetoothAdapterFallbackTests(unittest.TestCase):
         self.assertIsNotNone(caller_thread_id)
         self.assertIsNotNone(callback_thread_id)
         self.assertNotEqual(caller_thread_id, callback_thread_id)
+
+
+    def test_linux_att_connect_unpacks_address_channel_tuple(self) -> None:
+        # The shared adapter-fallback wrapper iterates over RFCOMM channels and
+        # passes the same (address, channel) tuple to every backend it owns,
+        # including the LE-only Linux direct-ATT socket. The L2CAP/ATT path
+        # has no use for the RFCOMM channel, but it must accept the tuple
+        # form rather than crashing on `tuple.replace`. Without this, the
+        # backend silently falls back to Bleak — which is the very path the
+        # Linux direct-ATT workaround was added to avoid (#23).
+        sock = _LinuxAttSocket()
+        captured: dict[str, object] = {}
+
+        def fake_open(address, address_type, *, timeout):
+            captured["address"] = address
+            raise OSError(errno.ENETUNREACH, "stop after capturing address")
+
+        with mock.patch(
+            "timiniprint.transport.bluetooth.adapters.linux_att._open_att_socket",
+            side_effect=fake_open,
+        ):
+            with self.assertRaises(RuntimeError):
+                sock.connect(("48:0F:57:C5:60:53", 1))
+
+        self.assertEqual(captured["address"], "48:0F:57:C5:60:53")
 
 
 if __name__ == "__main__":

--- a/tests/test_builder_pagination.py
+++ b/tests/test_builder_pagination.py
@@ -1,0 +1,93 @@
+"""Tests for the per-job-row pagination in PrintJobBuilder.
+
+When `TIMINI_PRINT_MAX_JOB_ROWS` is set and a rendered page is taller than
+the limit, the builder must split the raster vertically into sub-rasters
+each within the ceiling. We exercise the splitter directly with crafted
+RasterSets to keep the test hardware-independent.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from timiniprint.printing.builder import PrintJobBuilder, _resolve_max_job_rows
+from timiniprint.raster import PixelFormat, RasterBuffer, RasterSet
+
+
+class ResolveMaxJobRowsTests(unittest.TestCase):
+    def test_unset_returns_zero(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TIMINI_PRINT_MAX_JOB_ROWS", None)
+            self.assertEqual(_resolve_max_job_rows(), 0)
+
+    def test_positive_value(self) -> None:
+        with mock.patch.dict(os.environ, {"TIMINI_PRINT_MAX_JOB_ROWS": "200"}):
+            self.assertEqual(_resolve_max_job_rows(), 200)
+
+    def test_zero_disables_split(self) -> None:
+        with mock.patch.dict(os.environ, {"TIMINI_PRINT_MAX_JOB_ROWS": "0"}):
+            self.assertEqual(_resolve_max_job_rows(), 0)
+
+    def test_negative_disables_split(self) -> None:
+        with mock.patch.dict(os.environ, {"TIMINI_PRINT_MAX_JOB_ROWS": "-1"}):
+            self.assertEqual(_resolve_max_job_rows(), 0)
+
+    def test_non_numeric_disables_split(self) -> None:
+        with mock.patch.dict(os.environ, {"TIMINI_PRINT_MAX_JOB_ROWS": "lots"}):
+            self.assertEqual(_resolve_max_job_rows(), 0)
+
+
+def _bw1_raster(width: int, height: int) -> RasterSet:
+    pixels = [0] * (width * height)
+    return RasterSet.from_single(
+        RasterBuffer(pixels=pixels, width=width, pixel_format=PixelFormat.BW1)
+    )
+
+
+class _SplitterOnlyBuilder(PrintJobBuilder):
+    """Subclass we instantiate without the full device wiring; we only need
+    the unbound `_split_raster_for_max_rows` method, so we cheat past the
+    parent constructor."""
+
+    def __init__(self) -> None:  # type: ignore[no-untyped-def]
+        pass
+
+
+class SplitRasterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.builder = _SplitterOnlyBuilder()
+
+    def test_no_split_when_max_is_zero(self) -> None:
+        raster_set = _bw1_raster(width=8, height=500)
+        segments = list(self.builder._split_raster_for_max_rows(raster_set, 0))
+        self.assertEqual(len(segments), 1)
+        self.assertIs(segments[0], raster_set)
+
+    def test_no_split_when_under_limit(self) -> None:
+        raster_set = _bw1_raster(width=8, height=100)
+        segments = list(self.builder._split_raster_for_max_rows(raster_set, 200))
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].height, 100)
+
+    def test_exact_multiple_of_limit(self) -> None:
+        raster_set = _bw1_raster(width=8, height=400)
+        segments = list(self.builder._split_raster_for_max_rows(raster_set, 200))
+        self.assertEqual([s.height for s in segments], [200, 200])
+
+    def test_ragged_tail_segment(self) -> None:
+        raster_set = _bw1_raster(width=8, height=450)
+        segments = list(self.builder._split_raster_for_max_rows(raster_set, 200))
+        self.assertEqual([s.height for s in segments], [200, 200, 50])
+
+    def test_preserves_width_and_pixel_format(self) -> None:
+        raster_set = _bw1_raster(width=384, height=300)
+        segments = list(self.builder._split_raster_for_max_rows(raster_set, 100))
+        for segment in segments:
+            self.assertEqual(segment.width, 384)
+            for raster in segment.rasters.values():
+                self.assertEqual(raster.pixel_format, PixelFormat.BW1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/timiniprint/printing/builder.py
+++ b/timiniprint/printing/builder.py
@@ -1,15 +1,44 @@
 from __future__ import annotations
 
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import Iterable, Optional, TYPE_CHECKING
 
 from ..printing.runtime.base import PreparedRuntimeContext
 from ..protocol.family import ProtocolFamily
 from ..protocol.job import PrinterProtocol, ProtocolJob
+from ..protocol.steps import ProtocolStep, ProtocolStepOperation
 from ..protocol.types import ImageEncoding
+from ..raster import PixelFormat, RasterBuffer, RasterSet
 from ..rendering.converters import Page, PageLoader
 from ..rendering.renderer import apply_page_transforms, image_to_raster_set
 from .settings import PrintSettings
+
+
+_MAX_JOB_ROWS_ENV = "TIMINI_PRINT_MAX_JOB_ROWS"
+
+
+def _resolve_max_job_rows() -> int:
+    """Return the env-configured per-job row ceiling, or 0 if unset.
+
+    Some printer firmwares (notably MXW01 v1.9.3.1.2 in the V5X family)
+    silently truncate jobs taller than a few hundred rows of 384-px-wide
+    raster. Setting ``TIMINI_PRINT_MAX_JOB_ROWS=200`` (or similar) makes
+    the builder split tall pages into multiple back-to-back V5X sessions,
+    each below the firmware ceiling, sent as separate ``ProtocolStep``s
+    so the runtime can pace them and the printer never receives more
+    rows in one session than it can render.
+
+    Returns 0 (= no splitting) when the env var is unset, empty,
+    non-numeric, or non-positive.
+    """
+    raw = os.environ.get(_MAX_JOB_ROWS_ENV)
+    if not raw:
+        return 0
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0
+    return value if value > 0 else 0
 
 if TYPE_CHECKING:
     from ..devices import PrinterDevice
@@ -52,8 +81,9 @@ class PrintJobBuilder:
             runtime_capabilities=self.runtime_context.capabilities,
         ).formats[:1]
         gamma_handle, gamma_value = self._resolve_gray_preprocessing()
+        max_job_rows = _resolve_max_job_rows()
         payload_parts: list[bytes] = []
-        steps = []
+        steps: list[ProtocolStep] = []
         page_count = len(pages)
         for page_index, page in enumerate(pages, start=1):
             is_text = self._select_text_mode(page)
@@ -64,22 +94,39 @@ class PrintJobBuilder:
                 gamma_handle=gamma_handle,
                 gamma_value=gamma_value,
             )
-            page_job = self.protocol.build_job(
-                raster_set,
-                is_text=is_text,
-                blackening=self.settings.blackening,
-                feed_padding=self.settings.feed_padding,
-                paper_mode=self.settings.paper_mode,
-                lsb_first=self._lsb_first(),
-                image_encoding_override=self.settings.image_encoding_override,
-                pixel_format_override=self.settings.pixel_format_override,
-                page_index=page_index,
-                page_count=page_count,
-                runtime_capabilities=self.runtime_context.capabilities,
-                runtime_controller=self.runtime_context.runtime_controller,
-            )
-            payload_parts.append(page_job.payload)
-            steps.extend(page_job.steps)
+            for segment_index, segment_set in enumerate(
+                self._split_raster_for_max_rows(raster_set, max_job_rows)
+            ):
+                page_job = self.protocol.build_job(
+                    segment_set,
+                    is_text=is_text,
+                    blackening=self.settings.blackening,
+                    feed_padding=self.settings.feed_padding,
+                    paper_mode=self.settings.paper_mode,
+                    lsb_first=self._lsb_first(),
+                    image_encoding_override=self.settings.image_encoding_override,
+                    pixel_format_override=self.settings.pixel_format_override,
+                    page_index=page_index,
+                    page_count=page_count,
+                    runtime_capabilities=self.runtime_context.capabilities,
+                    runtime_controller=self.runtime_context.runtime_controller,
+                )
+                payload_parts.append(page_job.payload)
+                if page_job.steps:
+                    steps.extend(page_job.steps)
+                elif max_job_rows > 0 and segment_index >= 0:
+                    # When pagination is in effect we want each sub-job to be
+                    # sent as a discrete protocol step so the runtime can pace
+                    # them across the same connection without bleeding the
+                    # session boundary into the wrong characteristic.
+                    steps.append(
+                        ProtocolStep(
+                            label=f"page{page_index}-seg{segment_index + 1}",
+                            data=page_job.payload,
+                            operation=ProtocolStepOperation.SEND,
+                            include_in_payload=False,
+                        )
+                    )
         return ProtocolJob(
             runtime_controller=(
                 self.runtime_context.runtime_controller
@@ -88,6 +135,30 @@ class PrintJobBuilder:
             payload_segments=tuple(payload_parts),
             steps=tuple(steps),
         )
+
+    def _split_raster_for_max_rows(
+        self, raster_set: RasterSet, max_job_rows: int
+    ) -> Iterable[RasterSet]:
+        """Yield raster_set or a sequence of sub-sets each at most max_job_rows tall.
+
+        If max_job_rows is 0 (the default) or the raster fits, the original
+        raster_set is yielded unchanged.
+        """
+        if max_job_rows <= 0:
+            yield raster_set
+            return
+        height = raster_set.height
+        if height <= max_job_rows:
+            yield raster_set
+            return
+        for start_row in range(0, height, max_job_rows):
+            row_count = min(max_job_rows, height - start_row)
+            yield RasterSet(
+                rasters={
+                    pixel_format: raster.slice_rows(start_row, row_count)
+                    for pixel_format, raster in raster_set.rasters.items()
+                }
+            )
 
     def _resolve_gray_preprocessing(self) -> tuple[bool, Optional[float]]:
         pipeline = self.protocol.resolve_image_pipeline(

--- a/timiniprint/printing/runtime/v5x.py
+++ b/timiniprint/printing/runtime/v5x.py
@@ -175,7 +175,12 @@ class V5XRuntimeController(RuntimeController):
     async def before_split_command(self, session, packet: bytes, split_context: _V5XJobContext, *, timeout: float, density_updated: bool) -> None:
         opcode = session.extract_prefixed_opcode(packet)
         if opcode in (0xA2, 0xA9):
-            await self._wait_for_start_ready(session, timeout)
+            try:
+                await self._wait_for_start_ready(session, timeout)
+            except TimeoutError:
+                session.report_debug(
+                    f"V5X start ready (0xAA) not received before 0x{opcode:02x}; continuing"
+                )
 
     def arm_command_ack(self, session, packet: bytes) -> int | None:
         opcode = session.extract_prefixed_opcode(packet)
@@ -193,8 +198,13 @@ class V5XRuntimeController(RuntimeController):
         if ack_token is not None:
             ack_opcode = ack_token
             try:
-                await self._wait_for_command_ack(session, ack_opcode, timeout)
-                self._validate_command_ack(ack_opcode)
+                try:
+                    await self._wait_for_command_ack(session, ack_opcode, timeout)
+                    self._validate_command_ack(ack_opcode)
+                except TimeoutError:
+                    session.report_debug(
+                        f"V5X command ack 0x{ack_opcode:02x} not received within {timeout}s; continuing"
+                    )
             finally:
                 self._clear_command_ack_state(ack_opcode)
         if opcode == 0xA9:

--- a/timiniprint/transport/bluetooth/adapters/linux_att.py
+++ b/timiniprint/transport/bluetooth/adapters/linux_att.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import asyncio
 import ctypes
+import errno as errno_module
+import select
 import socket
 import struct
 import threading
@@ -349,7 +351,14 @@ class _LinuxAttClient:
         if self._sock is not None:
             self._sock.settimeout(timeout)
 
-    def connect(self, address: str) -> None:
+    def connect(self, address) -> None:
+        # The shared adapter-fallback wrapper passes the same address/channel
+        # tuple it iterates over to every backend, including this one.
+        # The RFCOMM channel is meaningless for an LE L2CAP/ATT socket — but
+        # we still have to accept the tuple form so we don't blow up before
+        # we get to the actual connect.
+        if isinstance(address, tuple):
+            address = address[0]
         self._reporter.debug(short="BLE", detail=f"Linux direct ATT connect: address={address}")
         last_error: Exception | None = None
         for address_type in (_BDADDR_LE_PUBLIC, _BDADDR_LE_RANDOM):
@@ -750,14 +759,21 @@ def _open_att_socket(address: str, address_type: int, *, timeout: float) -> sock
     if not hasattr(socket, "AF_BLUETOOTH"):
         raise RuntimeError("Python socket module lacks AF_BLUETOOTH support")
     sock = socket.socket(_AF_BLUETOOTH, socket.SOCK_SEQPACKET, _BTPROTO_L2CAP)
-    sock.settimeout(timeout)
     try:
         try:
             sock.setsockopt(_SOL_BLUETOOTH, _BT_SECURITY, struct.pack("I", _BT_SECURITY_LOW))
         except OSError:
             pass
         _bind_l2cap(sock, "00:00:00:00:00:00", _BDADDR_LE_PUBLIC)
-        _connect_l2cap(sock, address, address_type)
+        # The connect itself runs in blocking mode. Empirically, the
+        # AF_BLUETOOTH/L2CAP kernel path treats non-blocking connect
+        # (settimeout != None) differently and can hang indefinitely
+        # without marking the socket writable, even for peers that
+        # accept the connection cleanly in blocking mode. Apply the
+        # caller-requested timeout only after the connect has succeeded
+        # so it governs subsequent read/write operations.
+        _connect_l2cap(sock, address, address_type, timeout=timeout)
+        sock.settimeout(timeout)
         return sock
     except Exception:
         try:
@@ -779,13 +795,25 @@ def _bind_l2cap(sock: socket.socket, address: str, address_type: int) -> None:
             raise OSError(errno, "L2CAP bind failed")
 
 
-def _connect_l2cap(sock: socket.socket, address: str, address_type: int) -> None:
+def _connect_l2cap(sock: socket.socket, address: str, address_type: int, *, timeout: float | None = None) -> None:
     sockaddr = _make_sockaddr_l2(address, address_type)
     libc = ctypes.CDLL(None, use_errno=True)
     result = libc.connect(sock.fileno(), ctypes.byref(sockaddr), ctypes.sizeof(sockaddr))
-    if result != 0:
-        errno = ctypes.get_errno()
-        raise OSError(errno, "L2CAP ATT connect failed")
+    if result == 0:
+        return
+    err = ctypes.get_errno()
+    if err not in (errno_module.EINPROGRESS, errno_module.EALREADY, errno_module.EWOULDBLOCK):
+        raise OSError(err, "L2CAP ATT connect failed")
+    # When the caller put the socket in non-blocking mode (settimeout != None)
+    # the raw libc.connect() returns EINPROGRESS even though the kernel is
+    # still working on the L2CAP create-connection. Wait for the socket to
+    # become writable, then read SO_ERROR.
+    _, writable, _ = select.select([], [sock], [], timeout)
+    if not writable:
+        raise OSError(errno_module.ETIMEDOUT, "L2CAP ATT connect timed out")
+    so_error = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+    if so_error != 0:
+        raise OSError(so_error, "L2CAP ATT connect failed")
 
 
 def _make_sockaddr_l2(address: str, address_type: int) -> _SockaddrL2:


### PR DESCRIPTION
Replacement for #24. The earlier PR predated `1424fe3 linux bearer problem #23` on `master` and shipped a parallel `linux_l2cap_client.py` adapter (~1042 LoC). That parallel adapter is no longer the right shape: upstream's `linux_att.py` already takes the same architectural approach, so this PR keeps your code in place and instead fixes the wiring bugs that prevented it from working on at least one Linux host. The #25 host-side mitigations from #24 are preserved.

I'll close #24 after this one is in your review queue.

## Commits

### 1. `eddd640` Fix linux-att adapter wiring so it can actually connect on Linux

On Ubuntu 6.17 / BlueZ 5.83 / Python 3.12 (MXW01) `master` (post `1424fe3`/`d28d937`/`b8d38a5`) silently fell back to Bleak — i.e. the very BR/EDR-misroute path the linux-att workaround was added to bypass (#23). Three bugs:

1. **Tuple/string mismatch.** The shared `_FallbackSocket` iterates over `(address, channel)` tuples and passes the same tuple to every backend it owns. `_LinuxAttSocket.connect()` was typed as `(address: str)` and crashed on `tuple.replace()` inside address normalisation. Unpack the tuple before use; the RFCOMM channel is meaningless for an LE L2CAP/ATT socket so we discard it.
2. **EINPROGRESS not handled.** `_open_att_socket` previously called `sock.settimeout(timeout)` before the L2CAP connect, which puts the socket in non-blocking mode. The raw `libc.connect()` then returns -1 / `EINPROGRESS` instead of blocking. The old code raised that as a fatal error. Now we either select+SO_ERROR (when the caller already set a timeout), or use a blocking connect and apply the timeout afterwards.
3. **Non-blocking L2CAP connect hangs.** Even after the select+SO_ERROR fix, the AF_BLUETOOTH/L2CAP kernel path on this host never marked the socket writable, and the select() would time out after 30 s for a peer the blocking-mode equivalent connects to in <1 s. Switch to blocking mode for the connect itself, then `settimeout()` for subsequent read/writes.

Regression test for #1 in `tests/test_bluetooth_adapter_fallback.py`. #2 and #3 are exercised by the hardware Lorem-ipsum print below — unit tests for them would require faking `ctypes.CDLL` and are fragile relative to the underlying syscall behaviour.

### 2. `59bc714` Add per-job-rows pagination and tolerant V5X command-ack waits

For #25. Two host-side mitigations that don't unlock the firmware ceiling but improve the failure mode:

* **Pagination in `PrintJobBuilder`.** New env var `TIMINI_PRINT_MAX_JOB_ROWS` (default `0` = no split). When set, any rendered page raster taller than the limit is split vertically into sub-rasters and built as separate V5X sessions (`A7 / A2 / A9 / bulk / AD`), one per `ProtocolStep.SEND` so the runtime can pace them across one connection.
* **Tolerant runtime ACK waits in `printing/runtime/v5x.py`.** `_wait_for_start_ready` already logged-and-continued on a missing `0xAA`; `_wait_for_command_ack` did not. With pagination on, the second sub-job's `0xA7` ACK is preemptively consumed by a between-segments `0xA6` idle re-identification — so seg2's ACK never arrives and the wait raised an empty `asyncio.TimeoutError` that bubbled out as `Error: BLE write failed:` with no detail. Now caught and log-and-continued, mirroring the existing tolerance for `0xAA`.

10 new pagination unit tests in `tests/test_builder_pagination.py`. Updated `tests/test_bleak_transport_session.py::test_v5x_timeout_clears_pending_handshake_state` to assert the new "send completes, state still cleared" behaviour rather than the old "raise".

## Test plan

* [x] `python -m unittest discover -s tests -p 'test_*.py'` — 360/360 pass on this branch.
* [x] Live MXW01 (v1.9.3.1.2) on Linux + BlueZ:
  * BLE connect via `linux-att` succeeds in <1 s (`Linux direct ATT connected: address_type=1 mtu_payload=509 services=4`).
  * Short text print: clean run, `0xA9` status `0x0000`.
  * Lorem-ipsum repro at `TIMINI_BLE_BULK_DELAY_MS=30` (equivalent to `b8d38a5`'s bulk pacing on MTU-512 V5X): host-side ACKs clean (`0xA9` status `0x0000`, no `0xAA fc 20 73`-style distress bytes). Physical print **still truncates** at ~"ex ea commodo" (~37 %), confirming the residual constraint is in MXW01 firmware/render pipeline and not host-side. Documented in #25.
* [ ] CI on Linux x86_64/arm64, Windows, macOS arm64/intel (will run on push).

## Residual firmware constraint (for #25 reviewers)

Strongest hypothesis from the test sequence: MXW01 v1.9.3.1.2 has a *per-power-cycle* render budget (~200–300 rows of 384 px) rather than a per-job one. Once consumed, subsequent jobs are accepted at the protocol layer but produce no physical output. Pagination + tolerant acks make the failure mode graceful (the host doesn't abort, the printer doesn't cascade-fail subsequent jobs), but unlocking the ceiling needs firmware-side cooperation we don't have.

## Note on local BlueZ state during verification

On this host the linux-att L2CAP path occasionally hangs at connect-time when BlueZ has a stale entry for the device (e.g. after a failed connect via the dbus path). Running `bluetoothctl remove <addr>` clears that cleanly. Not an issue caused by this PR — but worth flagging since the symptom (silent connect timeout) is easy to mistake for the original #23 bug.