### PR TITLE
Fix Linux direct-ATT socket missing bulk payload support

### DIFF
--- a/timiniprint/transport/bluetooth/adapters/linux_att.py
+++ b/timiniprint/transport/bluetooth/adapters/linux_att.py
@@ -238,6 +238,25 @@ class _LinuxAttSocket:
             return False
         return self._transport.can_send_control_packet()
 
+    def can_send_bulk_payload(self) -> bool:
+        if not self._connected or self._client is None:
+            return False
+        return self._transport.can_send_bulk_payload()
+
+    def send_bulk_payload(self, data: bytes, *, timeout: float = 1.0) -> bool:
+        if not self._connected or self._client is None:
+            return False
+        return bool(
+            self._run(
+                self._transport.send_bulk_payload(
+                    self._client,
+                    data,
+                    mtu_size=self._mtu_size,
+                    timeout=timeout,
+                )
+            )
+        )
+
     def can_query_control_packet(self) -> bool:
         if not self._connected or self._client is None:
             return False


### PR DESCRIPTION
## Summary
- `_LinuxAttSocket` (the Linux direct-ATT connect workaround used when BlueZ/Bleak can't reliably reach a BLE-only printer) never implemented `can_send_bulk_payload()` / `send_bulk_payload()`, unlike the Bleak-based fallback socket in `bleak_adapter.py`.
- Any V5X-family printer routed through this Linux path (e.g. an MXW01 that advertises a misleading dual-mode BR/EDR+LE flag) failed every print with `Error: V5X bulk payload send unavailable`, since the backend's capability probe fell through to `False` when the methods were missing.
- Added the two missing methods, mirroring the existing pattern already used for `can_send_control_packet()` / `send_control_packet()` on the same class and matching the Bleak adapter's implementation.

## Test plan
- [x] `python -m unittest discover -s tests -p 'test_*.py'` — 630 tests, no new failures (2 pre-existing failures are unrelated, caused by a missing `packaging` module in the local venv).
- [x] Verified against real hardware (MXW01) on Linux with `--verbose`: before the fix, `send_protocol_steps` raised `V5X bulk payload send unavailable` immediately after connecting via the `linux-att` backend; after the fix, the bulk payload (12240 bytes / 68 chunks) sends successfully and the print completes.