### PR TITLE
Add opt-in flow control for tiny printers that report buffer state

### DIFF
--- a/tests/test_ble_transport_profiles.py
+++ b/tests/test_ble_transport_profiles.py
@@ -79,6 +79,14 @@ class BleTransportProfileTests(unittest.TestCase):
         v5c = get_ble_transport_profile(ProtocolFamily.V5C)
         self.assertTrue(v5c.flow_controlled_standard_write)
 
+    def test_tiny_profiles_enable_passive_buffer_flow_control(self) -> None:
+        for family in (ProtocolFamily.TINY, ProtocolFamily.TINY_PREFIXED):
+            with self.subTest(family=family.value):
+                profile = get_ble_transport_profile(family)
+                self.assertTrue(profile.prefer_generic_notify)
+                self.assertTrue(profile.flow_controlled_standard_write)
+                self.assertEqual(profile.flow_resume_timeout_s, 600.0)
+
     def test_unspecialized_families_keep_generic_transport_defaults(self) -> None:
         for family in (
             ProtocolFamily.LUCK_NORMAL,

--- a/tests/test_bleak_transport_session.py
+++ b/tests/test_bleak_transport_session.py
@@ -20,6 +20,7 @@ from timiniprint.devices.bluetooth_profiles import (
     get_ble_transport_profile,
 )
 from timiniprint.printing.runtime.v5c import V5CRuntimeController
+from timiniprint.printing.runtime.tiny import TinyRuntimeController
 from timiniprint.printing.runtime.v5g import V5GRuntimeController
 from timiniprint.printing.runtime.v5g_density import DensityLevels
 from timiniprint.printing.runtime.v5x import V5XRuntimeController
@@ -45,6 +46,7 @@ from timiniprint.protocol.families.v5x import (
     V5X_STATUS_POLL_PACKET,
 )
 from timiniprint.protocol.families.v5c import V5C_CONNECT_INIT_PACKET
+from timiniprint.protocol.families.tiny import TINY_NOTIFY_RESUME
 from timiniprint.protocol.packet import crc8_value, make_packet, prefixed_packet_opcode
 from timiniprint.protocol.steps import ProtocolStep
 from timiniprint.transport.bluetooth.adapters.bleak_adapter_endpoint_resolver import (
@@ -159,6 +161,8 @@ def _enable_notification_waits(session: _BleakTransportSession) -> None:
 
 
 def _runtime_controller_for_test(family: ProtocolFamily):
+    if family in {ProtocolFamily.TINY, ProtocolFamily.TINY_PREFIXED}:
+        return TinyRuntimeController()
     if family is ProtocolFamily.V5G:
         return V5GRuntimeController()
     if family is ProtocolFamily.V5X:
@@ -1675,6 +1679,37 @@ class BleakTransportSessionTests(unittest.TestCase):
 
         self.assertEqual(client.calls, [])
         self.assertFalse(session.flow_can_write)
+
+    def test_tiny_flow_resume_uses_profile_timeout_instead_of_send_timeout(self) -> None:
+        session, client = self._make_session(ProtocolFamily.TINY)
+        write_char = _Char(
+            "0000ae01-0000-1000-8000-00805f9b34fb",
+            ["write-without-response"],
+        )
+        session.bindings.write_char = write_char
+        session.bindings.write_selection_strategy = "preferred_uuid"
+        session.bindings.write_response_preference = False
+        session.bindings.write_char_uuid = write_char.uuid
+        session.flow_can_write = False
+
+        async def run() -> None:
+            async def resume() -> None:
+                await asyncio.sleep(0.02)
+                session.handle_notification(TINY_NOTIFY_RESUME)
+
+            task = asyncio.create_task(resume())
+            await session.send(
+                client,
+                b"ABC",
+                mtu_size=180,
+                timeout=0.01,
+            )
+            await task
+
+        asyncio.run(run())
+
+        self.assertEqual(client.calls, [(write_char.uuid, b"ABC", False)])
+        self.assertTrue(session.flow_can_write)
 
     def test_v5c_notifications_update_session_state(self) -> None:
         session, _ = self._make_session(ProtocolFamily.V5C)

--- a/tests/test_bluetooth_backend_connect.py
+++ b/tests/test_bluetooth_backend_connect.py
@@ -167,6 +167,17 @@ class _RuntimeControllerSpy:
         self.received.set()
 
 
+class _FlowRuntimeController:
+    def adopt_previous(self, _previous):
+        return None
+
+    def handle_notification(self, session, payload):
+        if payload == b"pause":
+            session.set_flow_paused(True, payload=payload)
+        elif payload == b"resume":
+            session.set_flow_paused(False, payload=payload)
+
+
 class _Adapter:
     def __init__(self, channels, fail=False, pair_error=None):
         self._channels = channels
@@ -377,6 +388,148 @@ class BluetoothBackendConnectTests(unittest.TestCase):
 
         self.assertEqual(sock.sent, [b"ab", b"cd", b"ef"])
         self.assertGreaterEqual(sleep_mock.call_count, 1)
+
+    def test_write_blocking_classic_waits_for_runtime_flow_resume(self) -> None:
+        reporter = _Reporter()
+        backend = SppBackend(
+            reporter=reporter,
+            classic_flow_resume_timeout_s=0.5,
+        )
+        sock = _Socket()
+        backend._sock = sock
+        backend._connected = True
+        backend._transport = DeviceTransport.CLASSIC
+        backend._classic_runtime_controller = _FlowRuntimeController()
+        backend._handle_classic_payload(b"pause")
+        errors = []
+
+        def write() -> None:
+            try:
+                backend._write_blocking(b"abcdef", chunk_size=2, delay_ms=0)
+            except Exception as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=write)
+        thread.start()
+        thread.join(timeout=0.05)
+
+        self.assertTrue(thread.is_alive())
+        self.assertEqual(sock.sent, [])
+
+        backend._handle_classic_payload(b"resume")
+        thread.join(timeout=0.5)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(sock.sent, [b"ab", b"cd", b"ef"])
+        details = [detail for _short, detail in reporter.debugs]
+        self.assertIn("Classic flow pause: 7061757365", details)
+        self.assertIn("Classic flow resume: 726573756d65", details)
+
+    def test_write_blocking_classic_stops_between_chunks(self) -> None:
+        backend = SppBackend(
+            reporter=reporting.DUMMY_REPORTER,
+            classic_flow_resume_timeout_s=0.5,
+        )
+        first_chunk_sent = threading.Event()
+
+        class _PauseAfterFirstChunkSocket(_Socket):
+            def sendall(self, data):
+                super().sendall(data)
+                if len(self.sent) == 1:
+                    backend._classic_runtime_session.set_flow_paused(True)
+                    first_chunk_sent.set()
+
+        sock = _PauseAfterFirstChunkSocket()
+        backend._sock = sock
+        backend._connected = True
+        backend._transport = DeviceTransport.CLASSIC
+        errors = []
+
+        def write() -> None:
+            try:
+                backend._write_blocking(b"abcdef", chunk_size=2, delay_ms=0)
+            except Exception as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=write)
+        thread.start()
+        self.assertTrue(first_chunk_sent.wait(timeout=0.2))
+        thread.join(timeout=0.05)
+
+        self.assertTrue(thread.is_alive())
+        self.assertEqual(sock.sent, [b"ab"])
+
+        backend._classic_runtime_session.set_flow_paused(False)
+        thread.join(timeout=0.5)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(sock.sent, [b"ab", b"cd", b"ef"])
+
+    def test_write_blocking_ble_does_not_use_classic_flow_gate(self) -> None:
+        backend = SppBackend(reporter=reporting.DUMMY_REPORTER)
+        sock = _Socket()
+        backend._sock = sock
+        backend._connected = True
+        backend._transport = DeviceTransport.BLE
+        backend._classic_runtime_session.set_flow_paused(True)
+
+        backend._write_blocking(b"abcdef", chunk_size=2, delay_ms=0)
+
+        self.assertEqual(sock.sent, [b"abcdef"])
+
+    def test_write_blocking_classic_flow_wait_times_out(self) -> None:
+        backend = SppBackend(
+            reporter=reporting.DUMMY_REPORTER,
+            classic_flow_resume_timeout_s=0.01,
+        )
+        sock = _Socket()
+        backend._sock = sock
+        backend._connected = True
+        backend._transport = DeviceTransport.CLASSIC
+        backend._classic_runtime_controller = _FlowRuntimeController()
+        backend._handle_classic_payload(b"pause")
+
+        with self.assertRaisesRegex(
+            TimeoutError,
+            "Classic Bluetooth flow-control resume",
+        ):
+            backend._write_blocking(b"ab", chunk_size=2, delay_ms=0)
+
+        self.assertEqual(sock.sent, [])
+
+    def test_disconnect_releases_classic_flow_waiter(self) -> None:
+        backend = SppBackend(
+            reporter=reporting.DUMMY_REPORTER,
+            classic_flow_resume_timeout_s=1.0,
+        )
+        sock = _Socket()
+        backend._sock = sock
+        backend._connected = True
+        backend._transport = DeviceTransport.CLASSIC
+        backend._classic_runtime_controller = _FlowRuntimeController()
+        backend._handle_classic_payload(b"pause")
+        errors = []
+
+        def write() -> None:
+            try:
+                backend._write_blocking(b"ab", chunk_size=2, delay_ms=0)
+            except Exception as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=write)
+        thread.start()
+        backend._disconnect_blocking()
+        thread.join(timeout=0.5)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(len(errors), 1)
+        self.assertRegex(
+            str(errors[0]),
+            "disconnected while waiting for flow-control resume",
+        )
+        self.assertEqual(sock.sent, [])
 
     def test_write_blocking_classic_reports_chunk_progress_for_large_payload(self) -> None:
         reporter = _Reporter()

--- a/tests/test_protocol_commands.py
+++ b/tests/test_protocol_commands.py
@@ -49,6 +49,31 @@ class ProtocolCommandsTests(unittest.TestCase):
             self.packet.split_prefixed_packets(first + b"\x00", ProtocolFamily.V5X)
         )
 
+    def test_prefixed_packet_stream_decoder_handles_fragmented_and_coalesced_frames(self) -> None:
+        pause = bytes.fromhex("5178AE0101001070FF")
+        resume = bytes.fromhex("5178AE0101000000FF")
+        decoder = self.packet.PrefixedPacketStreamDecoder(ProtocolFamily.TINY)
+
+        self.assertEqual(decoder.feed(b"\x00\x51"), ())
+        packets = decoder.feed(pause[1:] + resume)
+
+        self.assertEqual([packet.raw for packet in packets], [pause, resume])
+        self.assertEqual(
+            [(packet.opcode, packet.flags, packet.payload) for packet in packets],
+            [(0xAE, 1, b"\x10"), (0xAE, 1, b"\x00")],
+        )
+        self.assertEqual(decoder.pending, b"")
+
+    def test_prefixed_packet_stream_decoder_resynchronizes_after_invalid_crc(self) -> None:
+        pause = bytes.fromhex("5178AE0101001070FF")
+        resume = bytes.fromhex("5178AE0101000000FF")
+        invalid = pause[:-2] + b"\x00\xFF"
+        decoder = self.packet.PrefixedPacketStreamDecoder(ProtocolFamily.TINY)
+
+        packets = decoder.feed(invalid + resume)
+
+        self.assertEqual([packet.raw for packet in packets], [resume])
+
     def test_protocol_specs_expose_command_set(self) -> None:
         self.assertEqual(ProtocolFamily.TINY.command_set, ProtocolCommandSet.TINY)
         self.assertEqual(ProtocolFamily.TINY_PREFIXED.command_set, ProtocolCommandSet.TINY)

--- a/tests/test_rendering_document_renderer.py
+++ b/tests/test_rendering_document_renderer.py
@@ -70,6 +70,73 @@ class RenderingDocumentRendererTests(unittest.TestCase):
         self.assertEqual(image_renderer.preview_calls, 1)
         self.assertEqual(image_renderer.raster_calls, 1)
 
+    def test_source_preview_preserves_color_without_print_renderer(self) -> None:
+        image_renderer = _RecordingImageRenderer()
+        renderer = DocumentRenderer(
+            image_loader=lambda _path: Image.new("RGB", (40, 20), "red"),
+            image_renderer=image_renderer,
+        )
+
+        preview = renderer.preview_source_page(
+            RenderDocument("label.png"),
+            target_width=20,
+            target_height=20,
+        )
+
+        with Image.open(io.BytesIO(preview.png)) as image:
+            self.assertEqual(image.mode, "RGB")
+            self.assertEqual(image.getpixel((0, 0)), (255, 0, 0))
+            self.assertEqual(image.size, (20, 10))
+        self.assertEqual((preview.page_number, preview.page_count), (1, 1))
+        self.assertEqual(image_renderer.preview_calls, 0)
+        self.assertEqual(image_renderer.raster_calls, 0)
+
+    def test_source_preview_renders_requested_original_pdf_page(self) -> None:
+        pdf_renderer = _FakePdfRenderer(page_count=4)
+        renderer = DocumentRenderer(pdf_renderer=pdf_renderer)
+
+        preview = renderer.preview_source_page(
+            RenderDocument("document.pdf"),
+            page_index=2,
+            target_width=80,
+            target_height=80,
+        )
+
+        self.assertEqual(pdf_renderer.last_document.rendered_pages, [2])
+        self.assertEqual((preview.page_number, preview.page_count), (3, 4))
+        self.assertEqual((preview.width, preview.height), (80, 10))
+
+    def test_source_preview_rejects_invalid_pdf_page_with_index_error(self) -> None:
+        pdf_renderer = _FakePdfRenderer(page_count=4)
+        renderer = DocumentRenderer(pdf_renderer=pdf_renderer)
+
+        for page_index in (-1, 4):
+            with self.subTest(page_index=page_index):
+                with self.assertRaises(IndexError):
+                    renderer.preview_source_page(
+                        RenderDocument("document.pdf"),
+                        page_index=page_index,
+                        target_width=80,
+                        target_height=80,
+                    )
+
+    def test_source_preview_uses_existing_text_loader(self) -> None:
+        calls = []
+        renderer = DocumentRenderer(
+            text_loader=lambda source: calls.append(source) or "hello world",
+        )
+
+        preview = renderer.preview_source_page(
+            RenderDocument("content://note", "text/plain", "note.txt"),
+            target_width=120,
+            target_height=80,
+        )
+
+        self.assertEqual(calls, ["content://note"])
+        self.assertEqual(preview.width, 120)
+        self.assertLessEqual(preview.height, 80)
+        self.assertGreaterEqual(preview.page_count, 1)
+
     def test_paper_preset_render_width_is_used_for_preview_and_print(self) -> None:
         image_renderer = _RecordingImageRenderer()
         renderer = DocumentRenderer(

--- a/tests/test_tiny_flow_control.py
+++ b/tests/test_tiny_flow_control.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from timiniprint.devices import PrinterCatalog, get_ble_transport_profile
+from timiniprint.devices.profiles import RuntimeSettings
+from timiniprint.printing.runtime.factory import runtime_controller_for_device
+from timiniprint.printing.runtime.tiny import TinyRuntimeController
+from timiniprint.protocol.families.tiny import (
+    TINY_FLOW_PAUSE_PACKET,
+    TINY_FLOW_RESUME_PACKET,
+)
+from timiniprint.protocol.family import ProtocolFamily
+
+
+class _RecordingSession:
+    """Minimal session that records the flow decisions a controller makes."""
+
+    def __init__(self) -> None:
+        self.flow_calls: list[bool] = []
+        self.debug: list[str] = []
+
+    def set_flow_paused(self, paused: bool, *, payload: bytes = b"") -> None:
+        self.flow_calls.append(paused)
+
+    def report_debug(self, message: str) -> None:
+        self.debug.append(message)
+
+    def can_wait_for_notification(self) -> bool:
+        return False
+
+
+def _tiny_device(control_algorithm: str | None):
+    device = PrinterCatalog.load().device_from_profile("x5_2")
+    if control_algorithm is None:
+        return device
+    return replace(
+        device,
+        runtime_settings=RuntimeSettings(control_algorithm=control_algorithm),
+    )
+
+
+class TinyFlowControlTests(unittest.TestCase):
+    def test_pause_and_resume_frames_gate_the_write_loop(self) -> None:
+        controller = TinyRuntimeController()
+        session = _RecordingSession()
+
+        controller.handle_notification(session, TINY_FLOW_PAUSE_PACKET)
+        controller.handle_notification(session, TINY_FLOW_RESUME_PACKET)
+
+        self.assertEqual(session.flow_calls, [True, False])
+
+    def test_unrelated_notification_leaves_the_flow_alone(self) -> None:
+        controller = TinyRuntimeController()
+        session = _RecordingSession()
+
+        controller.handle_notification(session, bytes.fromhex("5178A30101002233FF"))
+
+        self.assertEqual(session.flow_calls, [])
+
+    def test_controller_is_opt_in_per_device(self) -> None:
+        # Without an opt-in a tiny device must keep the old behaviour: no
+        # controller, so nothing waits for frames the hardware may never send.
+        self.assertIsNone(runtime_controller_for_device(_tiny_device(None)))
+        self.assertIsInstance(
+            runtime_controller_for_device(_tiny_device("x5_poll")),
+            TinyRuntimeController,
+        )
+
+    def test_transport_profile_is_opt_in_per_control_algorithm(self) -> None:
+        plain = get_ble_transport_profile(ProtocolFamily.TINY)
+        self.assertFalse(plain.prefer_generic_notify)
+        self.assertFalse(plain.flow_controlled_standard_write)
+        self.assertIsNone(plain.flow_resume_timeout_s)
+
+        polling = get_ble_transport_profile(ProtocolFamily.TINY, "x5_poll")
+        self.assertTrue(polling.prefer_generic_notify)
+        self.assertTrue(polling.flow_controlled_standard_write)
+        # Hardware sent the resume frame 30-36s after pausing, so the budget has
+        # to outlast the send timeout by a wide margin.
+        self.assertIsNotNone(polling.flow_resume_timeout_s)
+        assert polling.flow_resume_timeout_s is not None
+        self.assertGreater(polling.flow_resume_timeout_s, 60.0)
+
+    def test_unknown_control_algorithm_falls_back_to_the_family(self) -> None:
+        fallback = get_ble_transport_profile(ProtocolFamily.TINY, "not_a_known_algorithm")
+        self.assertEqual(fallback, get_ble_transport_profile(ProtocolFamily.TINY))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tiny_flow_control.py
+++ b/tests/test_tiny_flow_control.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+
+from timiniprint.devices import PrinterCatalog
+from timiniprint.printing.runtime.factory import runtime_controller_for_device
+from timiniprint.printing.runtime.tiny import TinyRuntimeController
+from timiniprint.protocol.families.tiny import (
+    TINY_NOTIFY_PAUSE,
+    TINY_NOTIFY_RESUME,
+)
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.flow_calls: list[tuple[bool, bytes]] = []
+
+    def set_flow_paused(self, paused: bool, *, payload: bytes = b"") -> None:
+        self.flow_calls.append((paused, payload))
+
+
+class TinyFlowControlTests(unittest.TestCase):
+    def test_runtime_handles_fragmented_and_coalesced_notifications(self) -> None:
+        controller = TinyRuntimeController()
+        session = _RecordingSession()
+
+        controller.handle_notification(session, TINY_NOTIFY_PAUSE[:4])
+        controller.handle_notification(
+            session,
+            TINY_NOTIFY_PAUSE[4:] + TINY_NOTIFY_RESUME,
+        )
+
+        self.assertEqual(
+            session.flow_calls,
+            [
+                (True, TINY_NOTIFY_PAUSE),
+                (False, TINY_NOTIFY_RESUME),
+            ],
+        )
+
+    def test_runtime_ignores_unrelated_tiny_notification(self) -> None:
+        controller = TinyRuntimeController()
+        session = _RecordingSession()
+
+        controller.handle_notification(
+            session,
+            bytes.fromhex("5178A30101000000FF"),
+        )
+
+        self.assertEqual(session.flow_calls, [])
+
+    def test_runtime_is_enabled_for_both_tiny_prefix_variants(self) -> None:
+        catalog = PrinterCatalog.load()
+        for advertised_name in ("X5", "LP100"):
+            with self.subTest(advertised_name=advertised_name):
+                device = catalog.detect_device(advertised_name)
+                self.assertIsNotNone(device)
+                assert device is not None
+                self.assertIsInstance(
+                    runtime_controller_for_device(device),
+                    TinyRuntimeController,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/timiniprint/devices/bluetooth_profiles.py
+++ b/timiniprint/devices/bluetooth_profiles.py
@@ -22,6 +22,7 @@ class BleTransportProfile:
     notify_char_uuid: str = ""
     prefer_generic_notify: bool = False
     flow_controlled_standard_write: bool = False
+    flow_resume_timeout_s: float | None = None
     bulk_write: BleBulkWriteProfile | None = None
     # Some BLE writers need a smaller application chunk than the reported ATT
     # payload for write-without-response transfers.
@@ -30,9 +31,16 @@ class BleTransportProfile:
 
 _FALLBACK_PROFILE = BleTransportProfile()
 
+_TINY_TRANSPORT_PROFILE = BleTransportProfile(
+    standard_chunk_cap=512,
+    prefer_generic_notify=True,
+    flow_controlled_standard_write=True,
+    flow_resume_timeout_s=600.0,
+)
+
 _PROFILES = {
-    ProtocolFamily.TINY: BleTransportProfile(standard_chunk_cap=512),
-    ProtocolFamily.TINY_PREFIXED: BleTransportProfile(standard_chunk_cap=512),
+    ProtocolFamily.TINY: _TINY_TRANSPORT_PROFILE,
+    ProtocolFamily.TINY_PREFIXED: _TINY_TRANSPORT_PROFILE,
     ProtocolFamily.V5G: BleTransportProfile(
         prefer_generic_notify=True,
         standard_chunk_cap=56 * 8,

--- a/timiniprint/devices/bluetooth_profiles.py
+++ b/timiniprint/devices/bluetooth_profiles.py
@@ -22,6 +22,10 @@ class BleTransportProfile:
     notify_char_uuid: str = ""
     prefer_generic_notify: bool = False
     flow_controlled_standard_write: bool = False
+    # Seconds to wait for a resume frame before giving up. None keeps the send
+    # timeout, which is right for a link that should answer promptly; printers
+    # that pause to drain a print buffer need far longer than that.
+    flow_resume_timeout_s: float | None = None
     bulk_write: BleBulkWriteProfile | None = None
     # Some BLE writers need a smaller application chunk than the reported ATT
     # payload for write-without-response transfers.
@@ -91,9 +95,38 @@ _PROFILES = {
 
 DEFAULT_BLE_TRANSPORT_PROFILE = _PROFILES[ProtocolFamily.TINY]
 
+# Transport behaviour selected by runtime control algorithm rather than family.
+# Standard writes are write-without-response, so the transport has no
+# back-pressure of its own: it pushes a whole job out in seconds while the
+# printer needs minutes, and whatever does not fit is dropped silently. A device
+# that reports when it cannot take more can gate the write loop instead.
+#
+# Opt-in per device, not per family: one tested unit says nothing about the rest
+# of a family, and subscribing to notifications changes behaviour for every
+# device that would resolve to it.
+_CONTROL_ALGORITHM_PROFILES = {
+    # Verified on an X5 (advertised name "X5", profile x5_2, BLE). It sends the
+    # tiny pause/resume frames on a generic notify characteristic. Measured with
+    # a 54800-byte job: it paused twice and sent the resume frame after 35.8s
+    # and 30.2s, so the resume budget must be far larger than the send timeout
+    # of 30s -- which missed both by a hair and made the resume frame look like
+    # it did not exist at all.
+    "x5_poll": BleTransportProfile(
+        standard_chunk_cap=512,
+        prefer_generic_notify=True,
+        flow_controlled_standard_write=True,
+        flow_resume_timeout_s=600.0,
+    ),
+}
+
 
 def get_ble_transport_profile(
     protocol_family: ProtocolFamily | str | None,
+    control_algorithm: str | None = None,
 ) -> BleTransportProfile:
+    if control_algorithm:
+        override = _CONTROL_ALGORITHM_PROFILES.get(control_algorithm)
+        if override is not None:
+            return override
     family = ProtocolFamily.from_value(protocol_family)
     return _PROFILES.get(family, _FALLBACK_PROFILE)

--- a/timiniprint/devices/device.py
+++ b/timiniprint/devices/device.py
@@ -126,7 +126,11 @@ class PrinterDevice:
 
     @property
     def ble_transport_profile(self) -> BleTransportProfile:
-        return get_ble_transport_profile(self.protocol_family)
+        runtime = self.runtime_settings
+        return get_ble_transport_profile(
+            self.protocol_family,
+            None if runtime is None else runtime.control_algorithm,
+        )
 
     def with_transport_target(self, transport_target: Optional[TransportTarget]) -> "PrinterDevice":
         """Return a copy of this device with a different transport target."""

--- a/timiniprint/printing/document_renderer.py
+++ b/timiniprint/printing/document_renderer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from io import BytesIO
 from typing import Callable, Optional
 
 from PIL import Image, ImageOps
@@ -171,6 +172,62 @@ class DocumentRenderer:
             raster_height=preview.height,
             page_count=plan.page_count,
             page_number=page.index + 1,
+        )
+
+    def preview_source_page(
+        self,
+        document: RenderDocument,
+        page_index: int = 0,
+        *,
+        target_width: int,
+        target_height: int | None = None,
+    ) -> PreviewPage:
+        """Render a document page for viewing, without printer transforms."""
+        if page_index < 0:
+            raise IndexError(f"Document page out of range: {page_index + 1}")
+        width = max(1, int(target_width))
+        height = None if target_height is None else max(1, int(target_height))
+        kind = self._document_kind(document)
+        if kind == "image":
+            if page_index != 0:
+                raise IndexError(f"Document page out of range: {page_index + 1}")
+            source = ImageConverter(
+                image_loader=self.image_loader,
+                trim_side_margins=False,
+                trim_top_bottom_margins=False,
+            ).open(document.source, width)
+        elif kind == "pdf":
+            source = PdfConverter(
+                trim_side_margins=False,
+                trim_top_bottom_margins=False,
+                render_dpi=144,
+                pdf_renderer=self.pdf_renderer,
+            ).open(document.source, width)
+        elif kind == "text":
+            source = TextConverter(
+                font_path=self.text_font_resolver(None),
+                page_height_to_width=(
+                    None if height is None else height / width
+                ),
+            ).open_text(self._text_content(document), width)
+        else:
+            raise ValueError("Supported file formats: png, jpg, jpeg, gif, bmp, webp, pdf, txt")
+
+        with source:
+            if page_index >= source.page_count:
+                raise IndexError(f"Document page out of range: {page_index + 1}")
+            image = source.page(page_index).image.copy()
+            page_count = source.source_page_count
+        if height is not None and image.height > height:
+            image.thumbnail((width, height), Image.Resampling.LANCZOS)
+        return PreviewPage(
+            png=_color_png(image),
+            width=image.width,
+            height=image.height,
+            raster_width=image.width,
+            raster_height=image.height,
+            page_count=page_count,
+            page_number=page_index + 1,
         )
 
     def print_page(
@@ -351,3 +408,9 @@ def _white_for_mode(mode: str) -> str | int | tuple[int, ...]:
     if mode == "RGBA":
         return (255, 255, 255, 255)
     return "white"
+
+
+def _color_png(image: Image.Image) -> bytes:
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()

--- a/timiniprint/printing/runtime/factory.py
+++ b/timiniprint/printing/runtime/factory.py
@@ -7,6 +7,7 @@ from .base import RuntimeController
 from .funny_lx import FunnyLxRuntimeController
 from .luck_normal import LuckNormalRuntimeController
 from .niimbot import NiimbotRuntimeController
+from .tiny import TinyRuntimeController
 from .v5c import V5CRuntimeController
 from .v5g import V5GRuntimeController
 from .v5x import V5XRuntimeController
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
 
 
 def runtime_controller_for_device(device: PrinterDevice) -> RuntimeController | None:
+    if device.protocol_family in {ProtocolFamily.TINY, ProtocolFamily.TINY_PREFIXED}:
+        return TinyRuntimeController()
     if device.protocol_family is ProtocolFamily.V5G:
         return V5GRuntimeController(
             runtime_settings=device.runtime_settings,

--- a/timiniprint/printing/runtime/factory.py
+++ b/timiniprint/printing/runtime/factory.py
@@ -7,6 +7,7 @@ from .base import RuntimeController
 from .funny_lx import FunnyLxRuntimeController
 from .luck_normal import LuckNormalRuntimeController
 from .niimbot import NiimbotRuntimeController
+from .tiny import TINY_FLOW_CONTROL_ALGORITHMS, TinyRuntimeController
 from .v5c import V5CRuntimeController
 from .v5g import V5GRuntimeController
 from .v5x import V5XRuntimeController
@@ -26,6 +27,12 @@ def runtime_controller_for_device(device: PrinterDevice) -> RuntimeController | 
         return V5CRuntimeController()
     if device.protocol_family is ProtocolFamily.NIIMBOT:
         return NiimbotRuntimeController()
+    if (
+        device.protocol_family is ProtocolFamily.TINY
+        and device.runtime_settings is not None
+        and device.runtime_settings.control_algorithm in TINY_FLOW_CONTROL_ALGORITHMS
+    ):
+        return TinyRuntimeController()
     if device.protocol_family is ProtocolFamily.FUNNY_LX:
         return FunnyLxRuntimeController(bluetooth_address=device.address)
     if (

--- a/timiniprint/printing/runtime/tiny.py
+++ b/timiniprint/printing/runtime/tiny.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+from ...protocol.families.tiny import (
+    TINY_FLOW_PAUSE_PACKET,
+    TINY_FLOW_RESUME_PACKET,
+)
+from .base import RuntimeController, RuntimeSessionApi
+
+
+# Runtime control algorithms that select this controller. Devices opt in through
+# runtime_overrides.control_algorithm in their printer config, so nothing changes
+# for tiny printers that were never tested: one verified unit says nothing about
+# the rest of the family, and a controller that waits for frames a device never
+# sends would stall the job.
+TINY_FLOW_CONTROL_ALGORITHMS = frozenset({"x5_poll"})
+
+
+@dataclass
+class _TinySessionState:
+    pause_count: int = 0
+    resume_count: int = 0
+
+
+class TinyRuntimeController(RuntimeController):
+    """Flow control for tiny-family printers that report buffer state.
+
+    Standard writes are write-without-response, so the transport has no
+    back-pressure of its own: it pushes a whole job out in seconds while the
+    printer needs minutes, and whatever does not fit is dropped silently.
+
+    The device does report when it cannot take more. Same shape as V5C and V5X:
+    one pause frame, one resume frame, matched as complete packets.
+    """
+
+    _COMPLETION_QUIET_S: float = 3.0
+    _COMPLETION_GRACE_S: float = 3.0
+    _COMPLETION_MAX_S: float = 60.0
+
+    def __init__(self) -> None:
+        self._state = _TinySessionState()
+
+    def adopt_previous(self, previous: RuntimeController | None) -> None:
+        if isinstance(previous, TinyRuntimeController):
+            self._state = previous._state
+
+    def debug_snapshot(self) -> dict[str, object]:
+        return {
+            "pause_count": self._state.pause_count,
+            "resume_count": self._state.resume_count,
+        }
+
+    def debug_update(self, **changes: object) -> None:
+        for key, value in changes.items():
+            if not hasattr(self._state, key):
+                raise KeyError(f"Unknown tiny debug field '{key}'")
+            setattr(self._state, key, value)
+
+    def handle_notification(self, session: RuntimeSessionApi, payload: bytes) -> None:
+        if payload == TINY_FLOW_PAUSE_PACKET:
+            self._state.pause_count += 1
+            session.set_flow_paused(True, payload=payload)
+            return
+        if payload == TINY_FLOW_RESUME_PACKET:
+            self._state.resume_count += 1
+            session.set_flow_paused(False, payload=payload)
+            return
+        session.report_debug(f"tiny notify not recognised: {payload.hex()}")
+
+    async def wait_for_completion(self, session: RuntimeSessionApi, *, timeout: float) -> None:
+        # Hold the BLE link after the job is sent until the printer finishes.
+        # Same shape as the V5X controller: treat the job as done on the resume
+        # frame (the device reporting it is free) or after a quiet window with no
+        # frames, then wait a short grace before returning (caller disconnects).
+        # We only listen -- v5x.py notes that polling 0xA3 to elicit status would
+        # feed paper, and the tiny command set has no query known to be safe.
+        _ = timeout
+        if not session.can_wait_for_notification():
+            return
+        session.report_debug("tiny waiting for print completion before disconnect")
+        deadline = time.monotonic() + self._COMPLETION_MAX_S
+        capped = True
+        while time.monotonic() < deadline:
+            frame = await session.wait_for_notification(
+                "tiny flow resume",
+                lambda packet: packet == TINY_FLOW_RESUME_PACKET,
+                timeout=self._COMPLETION_QUIET_S,
+                required=False,
+            )
+            if frame is None:
+                session.report_debug("tiny status quiet; print assumed finished")
+                capped = False
+                break
+            session.report_debug("tiny reported free; print finished")
+            capped = False
+            break
+        if capped:
+            session.report_debug("tiny completion wait hit max cap; disconnecting anyway")
+        if self._COMPLETION_GRACE_S > 0:
+            await asyncio.sleep(self._COMPLETION_GRACE_S)

--- a/timiniprint/printing/runtime/tiny.py
+++ b/timiniprint/printing/runtime/tiny.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from ...protocol.family import ProtocolFamily
+from ...protocol.packet import PrefixedPacketStreamDecoder
+from .base import RuntimeController, RuntimeSessionApi
+
+
+class TinyRuntimeController(RuntimeController):
+    """Apply buffer flow-control notifications from the Tiny command dialect."""
+
+    def __init__(self) -> None:
+        # Both Tiny outbound prefix variants receive buffer notifications in
+        # the standard 51 78 packet dialect.
+        self._decoder = PrefixedPacketStreamDecoder(ProtocolFamily.TINY)
+
+    def adopt_previous(self, previous: RuntimeController | None) -> None:
+        if isinstance(previous, TinyRuntimeController):
+            self._decoder = previous._decoder
+
+    def handle_notification(
+        self,
+        session: RuntimeSessionApi,
+        payload: bytes,
+    ) -> None:
+        for packet in self._decoder.feed(payload):
+            if packet.opcode != 0xAE or packet.flags != 1:
+                continue
+            if packet.payload == b"\x10":
+                session.set_flow_paused(True, payload=packet.raw)
+            elif packet.payload == b"\x00":
+                session.set_flow_paused(False, payload=packet.raw)
+
+
+__all__ = ["TinyRuntimeController"]

--- a/timiniprint/protocol/families/tiny/__init__.py
+++ b/timiniprint/protocol/families/tiny/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
-from .core import BEHAVIOR
+from .core import (
+    BEHAVIOR,
+    TINY_FLOW_PAUSE_PACKET,
+    TINY_FLOW_RESUME_PACKET,
+)
 
-__all__ = ["BEHAVIOR"]
+__all__ = [
+    "BEHAVIOR",
+    "TINY_FLOW_PAUSE_PACKET",
+    "TINY_FLOW_RESUME_PACKET",
+]

--- a/timiniprint/protocol/families/tiny/__init__.py
+++ b/timiniprint/protocol/families/tiny/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .core import BEHAVIOR
+from .core import BEHAVIOR, TINY_NOTIFY_PAUSE, TINY_NOTIFY_RESUME
 
-__all__ = ["BEHAVIOR"]
+__all__ = ["BEHAVIOR", "TINY_NOTIFY_PAUSE", "TINY_NOTIFY_RESUME"]

--- a/timiniprint/protocol/families/tiny/core.py
+++ b/timiniprint/protocol/families/tiny/core.py
@@ -21,6 +21,8 @@ VARIANT_ESC_STAR = "esc_star"
 VARIANT_ESC_STAR_EIGHT = "esc_star_eight"
 VARIANT_PROFESSIONAL = "professional"
 EIGHT_PAPER_MODES = (PaperMode.PLAIN, PaperMode.A4_SHEET)
+TINY_NOTIFY_PAUSE = bytes.fromhex("5178AE0101001070FF")
+TINY_NOTIFY_RESUME = bytes.fromhex("5178AE0101000000FF")
 
 
 def _speed(request: PrintJobRequest) -> int:

--- a/timiniprint/protocol/families/tiny/core.py
+++ b/timiniprint/protocol/families/tiny/core.py
@@ -16,6 +16,14 @@ from ...types import ImageEncoding, ImagePipelineConfig, PaperMode
 from ..base import PrintJobRequest, ProtocolBehavior
 
 
+# Flow-control notifications. Both packets already appear in the V5X tables in
+# families/v5x.py (_FLOW_PAUSE_HEX / _FLOW_RESUME_HEX), which collect the same
+# two frames across several packet prefixes -- 5178 is the tiny prefix, so no
+# tiny-family printer ever matched them. Confirmed on hardware (advertised name
+# "X5", profile x5_2): the pause frame arrives part-way through a long transfer.
+TINY_FLOW_PAUSE_PACKET = bytes.fromhex("5178AE0101001070FF")
+TINY_FLOW_RESUME_PACKET = bytes.fromhex("5178AE0101000000FF")
+
 VARIANT_LINE_EIGHT = "line_eight"
 VARIANT_ESC_STAR = "esc_star"
 VARIANT_ESC_STAR_EIGHT = "esc_star_eight"

--- a/timiniprint/protocol/packet.py
+++ b/timiniprint/protocol/packet.py
@@ -1,10 +1,84 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional
 
 import crc8
 
 from .family import ProtocolFamily
+
+
+@dataclass(frozen=True)
+class PrefixedPacket:
+    raw: bytes
+    opcode: int
+    flags: int
+    payload: bytes
+
+
+class PrefixedPacketStreamDecoder:
+    """Decode fragmented or coalesced packets from a prefixed byte stream."""
+
+    def __init__(self, protocol_family: ProtocolFamily | str) -> None:
+        family = ProtocolFamily.from_value(protocol_family)
+        self._prefix = family.require_packet_prefix()
+        self._buffer = bytearray()
+
+    def feed(self, data: bytes) -> tuple[PrefixedPacket, ...]:
+        self._buffer.extend(data)
+        packets: list[PrefixedPacket] = []
+        prefix_length = len(self._prefix)
+        header_length = prefix_length + 4
+
+        while self._buffer:
+            marker = self._buffer.find(self._prefix)
+            if marker < 0:
+                keep = self._partial_prefix_length()
+                if keep:
+                    del self._buffer[:-keep]
+                else:
+                    self._buffer.clear()
+                break
+            if marker:
+                del self._buffer[:marker]
+            if len(self._buffer) < header_length:
+                break
+
+            payload_length_offset = prefix_length + 2
+            payload_length = int.from_bytes(
+                self._buffer[payload_length_offset : payload_length_offset + 2],
+                "little",
+            )
+            packet_length = header_length + payload_length + 2
+            if len(self._buffer) < packet_length:
+                break
+
+            raw = bytes(self._buffer[:packet_length])
+            payload = raw[header_length : header_length + payload_length]
+            if raw[-1] != 0xFF or crc8_value(payload) != raw[-2]:
+                del self._buffer[0]
+                continue
+            packets.append(
+                PrefixedPacket(
+                    raw=raw,
+                    opcode=raw[prefix_length],
+                    flags=raw[prefix_length + 1],
+                    payload=payload,
+                )
+            )
+            del self._buffer[:packet_length]
+        return tuple(packets)
+
+    @property
+    def pending(self) -> bytes:
+        return bytes(self._buffer)
+
+    def _partial_prefix_length(self) -> int:
+        limit = min(len(self._buffer), len(self._prefix) - 1)
+        for length in range(limit, 0, -1):
+            if self._buffer[-length:] == self._prefix[:length]:
+                return length
+        return 0
 
 
 def crc8_value(data: bytes) -> int:

--- a/timiniprint/transport/bluetooth/adapters/bleak_adapter_transport.py
+++ b/timiniprint/transport/bluetooth/adapters/bleak_adapter_transport.py
@@ -388,10 +388,13 @@ class _BleakTransportSession:
     async def _wait_for_flow(self, timeout: float) -> None:
         if self.flow_can_write:
             return
+        resume_timeout = self._transport_profile.flow_resume_timeout_s
+        if resume_timeout is None:
+            resume_timeout = timeout
         try:
             await asyncio.wait_for(
                 self._flow_resume_event_for_current_loop().wait(),
-                timeout=max(0.0, timeout),
+                timeout=max(0.0, resume_timeout),
             )
         except asyncio.TimeoutError:
             raise TimeoutError("Timed out waiting for BLE flow-control resume") from None

--- a/timiniprint/transport/bluetooth/adapters/bleak_adapter_transport.py
+++ b/timiniprint/transport/bluetooth/adapters/bleak_adapter_transport.py
@@ -388,13 +388,21 @@ class _BleakTransportSession:
     async def _wait_for_flow(self, timeout: float) -> None:
         if self.flow_can_write:
             return
+        # A paused device is working, not broken, and a printer can stay busy far
+        # longer than the send timeout. Profiles whose hardware pauses mid-job set
+        # their own resume budget; the default keeps the send timeout.
+        budget = self._transport_profile.flow_resume_timeout_s or timeout
+        waited_from = time.monotonic()
         try:
             await asyncio.wait_for(
                 self._flow_resume_event_for_current_loop().wait(),
-                timeout=max(0.0, timeout),
+                timeout=max(0.0, budget),
             )
         except asyncio.TimeoutError:
             raise TimeoutError("Timed out waiting for BLE flow-control resume") from None
+        self.report_debug(
+            f"BLE flow-control resumed after {time.monotonic() - waited_from:.1f}s"
+        )
 
     def handle_notification(self, payload: bytes) -> None:
         self._notification_count += 1

--- a/timiniprint/transport/bluetooth/backend.py
+++ b/timiniprint/transport/bluetooth/backend.py
@@ -15,13 +15,23 @@ from ... import reporting
 _MACOS_FALLBACK_COOLDOWN_SEC = 0.35
 _MACOS_BLE_REFRESH_TIMEOUT_SEC = 3.0
 _CONNECT_TIMEOUT_SEC = 12.0
+_CLASSIC_FLOW_RESUME_TIMEOUT_SEC = 600.0
 
 
 class _ClassicRuntimeSession:
     """Notification-side runtime adapter without protocol knowledge."""
 
-    def __init__(self, reporter: reporting.Reporter) -> None:
+    def __init__(
+        self,
+        reporter: reporting.Reporter,
+        *,
+        flow_resume_timeout_s: float = _CLASSIC_FLOW_RESUME_TIMEOUT_SEC,
+    ) -> None:
         self._reporter = reporter
+        self._flow_resume_timeout_s = max(0.0, float(flow_resume_timeout_s))
+        self._flow_condition = threading.Condition()
+        self._flow_paused = False
+        self._flow_closed = False
 
     def report_debug(self, message: str) -> None:
         self._reporter.debug(short="Runtime", detail=message)
@@ -30,11 +40,53 @@ class _ClassicRuntimeSession:
         self._reporter.warning(short=short, detail=detail)
 
     def set_flow_paused(self, paused: bool, *, payload: bytes = b"") -> None:
-        _ = paused, payload
+        with self._flow_condition:
+            if self._flow_closed:
+                return
+            changed = self._flow_paused != paused
+            self._flow_paused = paused
+            if not paused:
+                self._flow_condition.notify_all()
+        if changed:
+            label = "Classic flow pause" if paused else "Classic flow resume"
+            detail = "" if not payload else f": {payload.hex()}"
+            self.report_debug(label + detail)
+
+    def reopen_flow(self) -> None:
+        with self._flow_condition:
+            self._flow_paused = False
+            self._flow_closed = False
+            self._flow_condition.notify_all()
+
+    def close_flow(self) -> None:
+        with self._flow_condition:
+            self._flow_paused = False
+            self._flow_closed = True
+            self._flow_condition.notify_all()
+
+    def wait_for_flow(self) -> None:
+        deadline = time.monotonic() + self._flow_resume_timeout_s
+        with self._flow_condition:
+            while self._flow_paused and not self._flow_closed:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        "Timed out waiting for Classic Bluetooth flow-control resume"
+                    )
+                self._flow_condition.wait(timeout=remaining)
+            if self._flow_closed:
+                raise RuntimeError(
+                    "Classic Bluetooth disconnected while waiting for flow-control resume"
+                )
 
 
 class SppBackend:
-    def __init__(self, reporter: reporting.Reporter = reporting.DUMMY_REPORTER) -> None:
+    def __init__(
+        self,
+        reporter: reporting.Reporter = reporting.DUMMY_REPORTER,
+        *,
+        classic_flow_resume_timeout_s: float = _CLASSIC_FLOW_RESUME_TIMEOUT_SEC,
+    ) -> None:
         self._sock: Optional[SocketLike] = None
         self._lock = threading.Lock()
         self._classic_query_lock = threading.Lock()
@@ -44,7 +96,10 @@ class SppBackend:
         self._reporter = reporter
         self._classic_receive_hub: ClassicReceiveHub | None = None
         self._classic_runtime_controller = None
-        self._classic_runtime_session = _ClassicRuntimeSession(reporter)
+        self._classic_runtime_session = _ClassicRuntimeSession(
+            reporter,
+            flow_resume_timeout_s=classic_flow_resume_timeout_s,
+        )
 
     @staticmethod
     async def scan(timeout: float = 5.0) -> List[DeviceInfo]:
@@ -374,6 +429,7 @@ class SppBackend:
                 self._connected = True
                 self._channel = channel
                 self._transport = device.transport
+                self._classic_runtime_session.reopen_flow()
                 self._reporter.debug(
                     short="Bluetooth",
                     detail=(
@@ -407,6 +463,7 @@ class SppBackend:
         raise RuntimeError("Bluetooth connection failed (" + detail + ")")
 
     def _disconnect_blocking(self) -> None:
+        self._classic_runtime_session.close_flow()
         self._stop_classic_receive_hub()
         if not self._sock:
             self._connected = False
@@ -635,7 +692,10 @@ class SppBackend:
         chunk_index = 0
         while offset < len(data):
             chunk = data[offset : offset + chunk_size]
+            self._classic_runtime_session.wait_for_flow()
             with self._lock:
+                if not self._sock or not self._connected:
+                    raise RuntimeError("Not connected to a Bluetooth device")
                 _send_all(self._sock, chunk)
             offset += len(chunk)
             chunk_index += 1


### PR DESCRIPTION
Standard writes on the tiny family are write-without-response, so the
transport has no back-pressure: it pushes a whole job out in seconds while
the printer needs minutes, and whatever does not fit overwrites the end of
the buffer. Long jobs print fine for one buffer length; the rest comes out
as mostly skipped lines, with a few frames that made it in while the buffer
was emptying.

Listening to my own X5 (or a clone of one), I found that the protocol does
include pause and resume frames, but tiny never listens for them.

This commit implements the handling other families already have, for tiny,
behind an opt-in.

Behaviour:

- Opting in through runtime_overrides.control_algorithm = "x5_poll" is
  required. The standard x5 and x5_2 profiles are left unchanged.
- TinyRuntimeController maps the frames onto set_flow_paused and toggles
  accordingly: it listens for the pause, then for the resume.
- The transport stops sending after the pause, and picks up after the
  resume.
- The timeout is extended, as the pause can exceed the standard timeout
  delay of 30s.

The frames themselves are hard-coded. Should the hex values turn out to be
device-dependent for the X5 as well, this can become a config option.

Flow control lives in the bleak adapter, so this takes effect there only.
The Linux ATT, IOBluetooth and Windows adapters have no flow handling and
are untouched.

Hardware: printer advertising the name "X5", resolved profile x5_2, tiny
protocol, BLE through bleak on macOS 26.5 (arm64), Python 3.14.6, bleak
3.0.2, a 384x2297 receipt sent as a 54800-byte job. Before: clean
for roughly 1800 rows, the rest mostly skipped lines, and no trailing feed.
After: all 54800 bytes delivered and the receipt came out complete.

Reproduced with:
python3 timiniprint_command_line.py --bluetooth X5 \
    --printer-config printer.json verylongreceipt.png

Protocol behaviour was observed by listening to notifications on the
device's own notify characteristic; nothing was decompiled or taken from a
vendor application.

Tests: python3 -m unittest discover -s tests -q
667 tests, 2 pre-existing errors (test_app_gui and
test_gui_entrypoint_delegates_to_gui_main, both ModuleNotFoundError:
_tkinter on this Python build; they fail on a clean checkout too).
python3 tools/catalog_audit.py reports 0 errors, 0 warnings.
